### PR TITLE
Add support for multiple TCAs

### DIFF
--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -67,7 +67,7 @@ class TCA9548A_Channel():
 
     def unlock(self):
         """Pass thru for unlock."""
-        self.tca.i2c.writeto(self.tca.address, bytes([0]))
+        self.tca.i2c.writeto(self.tca.address, b'\x00')
         return self.tca.i2c.unlock()
 
     def readfrom_into(self, address, buffer, **kwargs):

--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -67,6 +67,7 @@ class TCA9548A_Channel():
 
     def unlock(self):
         """Pass thru for unlock."""
+        self.tca.i2c.writeto(self.tca.address, bytes([0]))
         return self.tca.i2c.unlock()
 
     def readfrom_into(self, address, buffer, **kwargs):


### PR DESCRIPTION
For #9 . Simple one liner to turn off all outputs when done with I2C transactions.
```python
Adafruit CircuitPython 4.0.1 on 2019-05-22; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import board, adafruit_tca9548A, adafruit_drv2605
>>> tca1 = adafruit_tca9548A.TCA9548A(board.I2C())
>>> tca2 = adafruit_tca9548A.TCA9548A(board.I2C(), address=0x71)
>>> tca3 = adafruit_tca9548A.TCA9548A(board.I2C(), address=0x72)
>>> drv1 = adafruit_drv2605.DRV2605(tca1[0])
>>> drv2 = adafruit_drv2605.DRV2605(tca2[0])
>>> drv3 = adafruit_drv2605.DRV2605(tca3[0])
>>> drv4 = adafruit_drv2605.DRV2605(tca3[3])
>>> drv1.play()
>>> drv2.play()
>>> drv3.play()
>>> drv4.play()
>>>
```
![tca_test](https://user-images.githubusercontent.com/8755041/60551628-bb455000-9ce0-11e9-9193-a5d1dee60a09.jpg)
