### PR TITLE
Possible fix for #11

### DIFF
--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -87,12 +87,17 @@ class TCA9548A_Channel():
         #In linux, at least, this is a special kernel function call
         if address == self.tca.address:
             raise ValueError("Device address must be different than TCA9548A address.")
-        
+
         if hasattr(self.tca.i2c, 'writeto_then_readfrom'):
             self.tca.i2c.writeto_then_readfrom(address, buffer_out, buffer_in, **kwargs)
         else:
-            self.tca.i2c.writeto(address, buffer_out, start=kwargs.get("out_start", 0), end=kwargs.get("out_end", None), stop=False)
-            self.tca.i2c.readfrom_into(address, buffer_in, start=kwargs.get("in_start", 0), end=kwargs.get("in_end", None))
+            self.tca.i2c.writeto(address, buffer_out,
+                                 start=kwargs.get("out_start", 0),
+                                 end=kwargs.get("out_end", None),
+                                 stop=False)
+            self.tca.i2c.readfrom_into(address, buffer_in,
+                                       start=kwargs.get("in_start", 0),
+                                       end=kwargs.get("in_end", None))
 
 class TCA9548A():
     """Class which provides interface to TCA9548A I2C multiplexer."""

--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -57,6 +57,9 @@ class TCA9548A_Channel():
     def __init__(self, tca, channel):
         self.tca = tca
         self.channel_switch = bytearray([1 << channel])
+        # provide only if needed
+        if hasattr(self.tca.i2c, 'writeto_then_readfrom'):
+            setattr(self, 'writeto_then_readfrom', self.writeto_then_readfrom_passthru)
 
     def try_lock(self):
         """Pass thru for try_lock."""
@@ -82,7 +85,7 @@ class TCA9548A_Channel():
             raise ValueError("Device address must be different than TCA9548A address.")
         return self.tca.i2c.writeto(address, buffer, **kwargs)
 
-    def writeto_then_readfrom(self, address, buffer_out, buffer_in, **kwargs):
+    def writeto_then_readfrom_passthru(self, address, buffer_out, buffer_in, **kwargs):
         """Pass thru for writeto_then_readfrom."""
         #In linux, at least, this is a special kernel function call
         if address == self.tca.address:

--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -57,9 +57,6 @@ class TCA9548A_Channel():
     def __init__(self, tca, channel):
         self.tca = tca
         self.channel_switch = bytearray([1 << channel])
-        # provide only if needed
-        if hasattr(self.tca.i2c, 'writeto_then_readfrom'):
-            setattr(self, 'writeto_then_readfrom', self.writeto_then_readfrom_passthru)
 
     def try_lock(self):
         """Pass thru for try_lock."""
@@ -85,12 +82,17 @@ class TCA9548A_Channel():
             raise ValueError("Device address must be different than TCA9548A address.")
         return self.tca.i2c.writeto(address, buffer, **kwargs)
 
-    def writeto_then_readfrom_passthru(self, address, buffer_out, buffer_in, **kwargs):
+    def writeto_then_readfrom(self, address, buffer_out, buffer_in, **kwargs):
         """Pass thru for writeto_then_readfrom."""
         #In linux, at least, this is a special kernel function call
         if address == self.tca.address:
             raise ValueError("Device address must be different than TCA9548A address.")
-        return self.tca.i2c.writeto_then_readfrom(address, buffer_out, buffer_in, **kwargs)
+        
+        if hasattr(self.tca.i2c, 'writeto_then_readfrom'):
+            self.tca.i2c.writeto_then_readfrom(address, buffer_out, buffer_in, **kwargs)
+        else:
+            self.tca.i2c.writeto(address, buffer_out, start=kwargs.get("out_start", 0), end=kwargs.get("out_end", None), stop=False)
+            self.tca.i2c.readfrom_into(address, buffer_in, start=kwargs.get("in_start", 0), end=kwargs.get("in_end", None))
 
 class TCA9548A():
     """Class which provides interface to TCA9548A I2C multiplexer."""


### PR DESCRIPTION
Can't just add logic in existing function since it would still `hasattr`. Need to dynamically provide it as needed.

Don't have an INA219 to test with original issue, but tested with an I2C FRAM and TCA:
**tca_fram_test.py**
```python
import board
import adafruit_fram
import adafruit_tca9548a

tca = adafruit_tca9548a.TCA9548A(board.I2C())

fram = adafruit_fram.FRAM_I2C(tca[0])

fram[0] = 1
print(fram[0])
```
 **RPI/Blinka**
```python
pi@pizerow:~ $ python3
Python 3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tca_fram_test
bytearray(b'\x01')
>>>
```
**ItsyM4/CP**
```python
Press any key to enter the REPL. Use CTRL-D to reload.
Adafruit CircuitPython 4.0.2 on 2019-06-27; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import tca_fram_test
bytearray(b'\x01')
>>>
```