### PR TITLE
Remove obsolete code (Fixes #20)

### DIFF
--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -71,23 +71,9 @@ class TCA9548A_Channel:
         # In linux, at least, this is a special kernel function call
         if address == self.tca.address:
             raise ValueError("Device address must be different than TCA9548A address.")
-
-        if hasattr(self.tca.i2c, "writeto_then_readfrom"):
-            self.tca.i2c.writeto_then_readfrom(address, buffer_out, buffer_in, **kwargs)
-        else:
-            self.tca.i2c.writeto(
-                address,
-                buffer_out,
-                start=kwargs.get("out_start", 0),
-                end=kwargs.get("out_end", None),
-                stop=False,
-            )
-            self.tca.i2c.readfrom_into(
-                address,
-                buffer_in,
-                start=kwargs.get("in_start", 0),
-                end=kwargs.get("in_end", None),
-            )
+        return self.tca.i2c.writeto_then_readfrom(
+            address, buffer_out, buffer_in, **kwargs
+        )
 
 
 class TCA9548A:


### PR DESCRIPTION
Address change requested in Issue #20 by making the following changes:

Refactor `writeto_then_readfrom()` to be consistent with the other methods in the class
by now returning `self_tca_i2c.writeto_then_readfrom()`

Remove obsolete code in `writeto_then_readfrom()` as per @jepler in Issue #20

_I did test the changes to the extent I could (i.e., no errors at runtime and able to instantiate an adafruit_tca9548a.TCA9548A object in code), but I do not have a TCA9548A board to physically test_.