### PR TITLE
Add scan()

### DIFF
--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -75,6 +75,10 @@ class TCA9548A_Channel:
             address, buffer_out, buffer_in, **kwargs
         )
 
+    def scan(self):
+        """Perform an I2C Device Scan"""
+        return self.tca.i2c.scan()
+
 
 class TCA9548A:
     """Class which provides interface to TCA9548A I2C multiplexer."""


### PR DESCRIPTION
For #26. Nice and simple, just defer to underlying I2C.

Example with a BME680 attached to TCA channel 4:
```python
Adafruit CircuitPython 6.1.0 on 2021-01-21; Adafruit QT Py M0 with samd21e18
>>> import board
>>> import adafruit_tca9548a
>>> tca = adafruit_tca9548a.TCA9548A(board.I2C())
>>> tca[4].try_lock()
True
>>> tca[4].scan()
[112, 118]
>>> 
```
112 is the TCA, 118 is the BME.