### PR TITLE
Bugfix Channel Scan

### DIFF
--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -77,7 +77,11 @@ class TCA9548A_Channel:
 
     def scan(self):
         """Perform an I2C Device Scan"""
-        return self.tca.i2c.scan()
+        self.try_lock()
+        try:
+            return self.tca.i2c.scan()
+        finally:
+            self.unlock()
 
 
 class TCA9548A:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,12 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/tca9548a_simpletest.py
     :caption: examples/tca9548a_simpletest.py
     :linenos:
+
+Channel Scan
+-------------
+
+Ensure your device scans each channel of TCA9547A with Channel Scan.
+
+.. literalinclude:: ../examples/tca9548a_channelscan.py
+    :caption: examples/tca9548a_channelscan.py
+    :linenos:

--- a/examples/tca9548a_channelscan.py
+++ b/examples/tca9548a_channelscan.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2021 codenio (Aananth K)
+# SPDX-License-Identifier: MIT
+
+# This example shows scanning of each TCA9548A channels.
+import board
+import busio
+import adafruit_tca9548a
+
+# Create I2C bus as normal
+i2c = busio.I2C(board.SCL, board.SDA)
+
+# Create the TCA9548A object and give it the I2C bus
+tca = adafruit_tca9548a.TCA9548A(i2c)
+
+# Scan the Main I2C Channel present in your board
+print("Scan of Main I2C Channel:{}".format([hex(i) for i in i2c.scan()]))
+
+# Scan Each TCA9548A channel
+for i in range(8):
+    print("Scan of TCA[{}] Channel: {}".format(i, [hex(j) for j in tca[i].scan()]))


### PR DESCRIPTION
This PR addresses #31 ,
- Fixes Bug with Channel scan

**Action:**  To perform i2c scan on a particular channel in TCA9548A  

```python
...
# Initialize I2C bus.
i2c = busio.I2C(I2C1_SCL_PIN,I2C1_SDA_PIN)
# default TCA address=0x70
tca = adafruit_tca9548a.TCA9548A(i2c)

print([hex(i) for i in i2c.scan()])
print([hex(i) for i in tca[0].scan()])
...
```
**Bug:** It Performs i2c scan on actual i2c bus where TCA9548A is connected
```
$ python i2c-mux.py 
['0x70']
['0x70']
Press Entre to exit..
```


**Fix:** Perform i2c scan on selected channel
```shell
$ python i2c-mux.py 
['0x70']
['0x60', '0x70'] #MCP4725 DAC module is connected to channel 0 of TCA9548A
Press Entre to exit..
```
