### PR TITLE
make TCA work for slaves with same address or even in general

### DIFF
--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -62,12 +62,14 @@ class TCA9548A_Channel:
         """Pass through for readfrom_into."""
         if address == self.tca.address:
             raise ValueError("Device address must be different than TCA9548A address.")
+        self.tca.i2c.writeto(self.tca.address, self.channel_switch)
         return self.tca.i2c.readfrom_into(address, buffer, **kwargs)
 
     def writeto(self, address, buffer, **kwargs):
         """Pass through for writeto."""
         if address == self.tca.address:
             raise ValueError("Device address must be different than TCA9548A address.")
+        self.tca.i2c.writeto(self.tca.address, self.channel_switch)
         return self.tca.i2c.writeto(address, buffer, **kwargs)
 
     def writeto_then_readfrom(self, address, buffer_out, buffer_in, **kwargs):
@@ -75,6 +77,7 @@ class TCA9548A_Channel:
         # In linux, at least, this is a special kernel function call
         if address == self.tca.address:
             raise ValueError("Device address must be different than TCA9548A address.")
+        self.tca.i2c.writeto(self.tca.address, self.channel_switch)
         return self.tca.i2c.writeto_then_readfrom(
             address, buffer_out, buffer_in, **kwargs
         )


### PR DESCRIPTION
In order to route an i2c request to a connected slave, the tca itself has to make sure that the right path to the slave is set. There was no such thing in the code. If I am right, then without my code change, only one or no slave could be addressed... the reported bug one year ago sounds like suffering from this lack, too. 
I added this one line: "self.tca.i2c.writeto(self.tca.address, self.channel_switch)" before all requests (readfrom_into, writeto, and write_then_readfrom). With this, the TCA register will be set with the desired channel_switch. I do not know, whether this is thread safe. It might not... but without it, the TCA will not work at all. If so, please add it to the main branch. If am totally misunderstanding, then please just forget about this. In any case: Thank you for your time.