### PR TITLE
Wait for other thread to unlock when not able to lock

### DIFF
--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -51,7 +51,6 @@ class TCA9548A_Channel:
         """Pass through for try_lock."""
         while not self.tca.i2c.try_lock():
             time.sleep(0)
-            pass
         self.tca.i2c.writeto(self.tca.address, self.channel_switch)
         return True
 

--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -29,6 +29,7 @@ Implementation Notes
 
 """
 
+import time
 from micropython import const
 
 _DEFAULT_ADDRESS = const(0x70)
@@ -49,6 +50,7 @@ class TCA9548A_Channel:
     def try_lock(self):
         """Pass through for try_lock."""
         while not self.tca.i2c.try_lock():
+            time.sleep(0)
             pass
         self.tca.i2c.writeto(self.tca.address, self.channel_switch)
         return True


### PR DESCRIPTION
This request adds a sleep call of `0` seconds in the try_lock function. This resolves an issue where the current thread is constantly trying to lock the i2c bus, without giving another thread the 'opportunity' to complete it's operation and unlock the i2c bus. 

This sleep call drastically improves performance on my pi zero board:
![image](https://user-images.githubusercontent.com/29043784/180801156-9eaefbdb-2eb1-44dc-81ed-942baa083b08.png)
^ without the sleep call

![image](https://user-images.githubusercontent.com/29043784/180801442-f1f43dd8-5b25-4575-b1a3-b218167af81f.png)
^ using the sleep call

I'm not sure if this is the right way of 'unblocking' the i2c bus for other threads, but it's for sure 1000x better than before for me. Therefore I feel like it's worth sharing with others.