### PR TITLE
Adding a PCA9546A class and examples

### DIFF
--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -116,3 +116,22 @@ class TCA9548A:
         if self.channels[key] is None:
             self.channels[key] = TCA9548A_Channel(self, key)
         return self.channels[key]
+
+
+class PCA9546A:
+    """Class which provides interface to TCA9546A I2C multiplexer."""
+
+    def __init__(self, i2c: I2C, address: int = _DEFAULT_ADDRESS) -> None:
+        self.i2c = i2c
+        self.address = address
+        self.channels = [None] * 4
+
+    def __len__(self) -> Literal[4]:
+        return 4
+
+    def __getitem__(self, key: Literal[0, 1, 2, 3]) -> "TCA9548A_Channel":
+        if not 0 <= key <= 3:
+            raise IndexError("Channel must be an integer in the range: 0-3.")
+        if self.channels[key] is None:
+            self.channels[key] = TCA9548A_Channel(self, key)
+        return self.channels[key]

--- a/examples/pca9546a_multisensor.py
+++ b/examples/pca9546a_multisensor.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+# This example shows using two TSL2491 light sensors attached to PCA9546A channels 0 and 1.
+# Use with other I2C sensors would be similar.
+import time
+import board
+import adafruit_tsl2591
+import adafruit_tca9548a
+
+# Create I2C bus as normal
+i2c = board.I2C()  # uses board.SCL and board.SDA
+# i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
+
+# Create the PCA9546A object and give it the I2C bus
+mux = adafruit_tca9548a.PCA9546A(i2c)
+
+# For each sensor, create it using the PCA9546A channel instead of the I2C object
+tsl1 = adafruit_tsl2591.TSL2591(mux[0])
+tsl2 = adafruit_tsl2591.TSL2591(mux[1])
+
+# After initial setup, can just use sensors as normal.
+while True:
+    print(tsl1.lux, tsl2.lux)
+    time.sleep(0.1)

--- a/examples/pca9546a_simpletest.py
+++ b/examples/pca9546a_simpletest.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2021 Carter Nelson for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+# This example shows using TCA9548A to perform a simple scan for connected devices
+import board
+import adafruit_tca9548a
+
+# Create I2C bus as normal
+i2c = board.I2C()  # uses board.SCL and board.SDA
+# i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
+
+# Create the PCA9546A object and give it the I2C bus
+mux = adafruit_tca9548a.PCA9546A(i2c)
+
+for channel in range(4):
+    if mux[channel].try_lock():
+        print("Channel {}:".format(channel), end="")
+        addresses = mux[channel].scan()
+        print([hex(address) for address in addresses if address != 0x70])
+        mux[channel].unlock()


### PR DESCRIPTION
Currently working on the PCA9546A product guides (PID 5663 and 5664) and I was concerned that using the 8 output mux example code would be confusing since these are 4 output muxes. Added a class for the PCA9546A and corresponding example code.