### PR TITLE
Add basic reset support

### DIFF
--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -37,6 +37,7 @@ try:
     from typing_extensions import Literal
     from circuitpython_typing import WriteableBuffer, ReadableBuffer
     from busio import I2C
+    from digitalio import DigitalInOut
 except ImportError:
     pass
 


### PR DESCRIPTION
This is for #30.

This may or may not be a good idea. Hoping people in that issue thread can test this against their use case since they have actual fail cases.

I was only able to test happy path:
```python
import time
import board
import digitalio
import adafruit_tca9548a
import adafruit_mma8451
import adafruit_bh1750

rst_pin = digitalio.DigitalInOut(board.D10)

i2c = board.I2C()
tca = adafruit_tca9548a.TCA9548A(i2c, reset=rst_pin)
mma8451 = adafruit_mma8451.MMA8451(tca[1])
bh1750 = adafruit_bh1750.BH1750(tca[4])

# initial readings
print(mma8451.acceleration)
print(bh1750.lux)

# reset
tca.reset()

# second readings
print(mma8451.acceleration)
print(bh1750.lux)
```

It works, but isn't super interesting since there was no actual failure that was needing to be recovered from.
```
Adafruit CircuitPython 8.2.7 on 2023-10-19; Adafruit Feather RP2040 with rp2040
>>> import test
(0.0191536, 0.148441, 9.7444)
65.4167
(0.0047884, 0.129287, 9.77313)
65.4167
>>>
```