### PR TITLE
try_lock increase sleep time from 0 to 1 ms

### DIFF
--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -58,7 +58,7 @@ class TCA9548A_Channel:
     def try_lock(self) -> bool:
         """Pass through for try_lock."""
         while not self.tca.i2c.try_lock():
-            time.sleep(0)
+            time.sleep(0.001)
         self.tca.i2c.writeto(self.tca.address, self.channel_switch)
         return True
 


### PR DESCRIPTION
Fix #52 

Increasing the sleep time from 0 ms to 1 ms decreases the CPU usage from 100% to 2% on my A64-OLinuXino.

I hope that 1 ms of delay will not affect anyone...

Maybe there is a smarter solution?