### PR TITLE
Add i2c probe compatibility

### DIFF
--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -98,6 +98,10 @@ class TCA9548A_Channel:
         """Perform an I2C Device Scan"""
         return self.tca.i2c.scan()
 
+    def probe(self, address: int) -> bool:
+        """Check if an I2C device is at the specified address on the hub."""
+        return self.tca.i2c.probe(address)
+
 
 class TCA9548A:
     """Class which provides interface to TCA9548A I2C multiplexer."""

--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -100,7 +100,10 @@ class TCA9548A_Channel:
 
     def probe(self, address: int) -> bool:
         """Check if an I2C device is at the specified address on the hub."""
-        return self.tca.i2c.probe(address)
+        # backwards compatibility for circuitpython <9.2
+        if hasattr(self.tca.i2c, "probe"):
+            return self.tca.i2c.probe(address)
+        return address in self.scan()
 
 
 class TCA9548A:


### PR DESCRIPTION
Attempting to resolve #54 with some backwards compatibility for circuitpython <9.2.