### PR TITLE
Fix return type

### DIFF
--- a/adafruit_tca9548a.py
+++ b/adafruit_tca9548a.py
@@ -64,7 +64,7 @@ class TCA9548A_Channel:
         self.tca.i2c.writeto(self.tca.address, self.channel_switch)
         return True
 
-    def unlock(self) -> bool:
+    def unlock(self) -> None:
         """Pass through for unlock."""
         self.tca.i2c.writeto(self.tca.address, b"\x00")
         return self.tca.i2c.unlock()


### PR DESCRIPTION
unlock() always returns None, but was incorrectly type hinted as bool.
Hopefully I didn't miss any documentation...